### PR TITLE
Update extension to accept more than 1 column on delete updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ coverage
 
 # Mac
 .DS_Store
+
+# Yarn
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "typecheck": "npm run build:cjs -- --noEmit && npm run build:esm -- --noEmit",
     "validate": "kcd-scripts validate lint,typecheck,test",
     "semantic-release": "semantic-release",
-    "doctoc": "doctoc ."
+    "doctoc": "doctoc .",
+    "postinstall": "tsc --outDir ./build"
   },
   "files": [
     "dist"

--- a/src/lib/createSoftDeleteExtension.ts
+++ b/src/lib/createSoftDeleteExtension.ts
@@ -35,7 +35,7 @@ export function createSoftDeleteExtension({
   models,
   defaultConfig = {
     field: "deleted",
-    createValue: Boolean,
+    createUpdates: (deleted: boolean) => ({ deleted }),
     allowToOneUpdates: false,
     allowCompoundUniqueIndexWhere: false,
   },
@@ -45,7 +45,7 @@ export function createSoftDeleteExtension({
       "prisma-extension-soft-delete: defaultConfig.field is required"
     );
   }
-  if (!defaultConfig.createValue) {
+  if (!defaultConfig.createUpdates) {
     throw new Error(
       "prisma-extension-soft-delete: defaultConfig.createValue is required"
     );

--- a/src/lib/helpers/createParams.ts
+++ b/src/lib/helpers/createParams.ts
@@ -40,7 +40,7 @@ export type CreateParams = (
 ) => CreateParamsReturn;
 
 export const createDeleteParams: CreateParams = (
-  { field, createValue },
+  { field, createUpdates },
   params
 ) => {
   if (
@@ -62,7 +62,7 @@ export const createDeleteParams: CreateParams = (
         operation: "update",
         args: {
           __passUpdateThrough: true,
-          [field]: createValue(true),
+          ...createUpdates(true),
         },
       },
     };
@@ -75,7 +75,7 @@ export const createDeleteParams: CreateParams = (
       args: {
         where: params.args?.where || params.args,
         data: {
-          [field]: createValue(true),
+          ...createUpdates(true),
         },
       },
     },
@@ -94,10 +94,10 @@ export const createDeleteManyParams: CreateParams = (config, params) => {
       args: {
         where: {
           ...where,
-          [config.field]: config.createValue(false),
+          ...config.createUpdates(false),
         },
         data: {
-          [config.field]: config.createValue(true),
+          ...config.createUpdates(true),
         },
       },
     },
@@ -136,8 +136,11 @@ export const createUpdateManyParams: CreateParams = (config, params) => {
         where: {
           ...params.args?.where,
           // allow overriding the deleted field in where
-          [config.field]:
-            params.args?.where?.[config.field] || config.createValue(false),
+          ...(params.args?.where?.[config.field]
+            ? {
+                [config.field]: params.args?.where?.[config.field],
+              }
+            : config.createUpdates(false)),
         },
       },
     },
@@ -154,10 +157,7 @@ export const createUpsertParams: CreateParams = (_, params) => {
   return { params };
 };
 
-function validateFindUniqueParams(
-  params: Params,
-  config: ModelConfig
-): void {
+function validateFindUniqueParams(params: Params, config: ModelConfig): void {
   const uniqueIndexFields = uniqueIndexFieldsByModel[params.model || ""] || [];
   const uniqueIndexField = Object.keys(params.args?.where || {}).find((key) =>
     uniqueIndexFields.includes(key)
@@ -215,7 +215,11 @@ export const createFindUniqueParams: CreateParams = (config, params) => {
         where: {
           ...params.args?.where,
           // allow overriding the deleted field in where
-          [config.field]: params.args?.where?.[config.field] || config.createValue(false),
+          ...(params.args?.where?.[config.field]
+            ? {
+                [config.field]: params.args?.where?.[config.field],
+              }
+            : config.createUpdates(false)),
         },
       },
     },
@@ -238,7 +242,11 @@ export const createFindUniqueOrThrowParams: CreateParams = (config, params) => {
         where: {
           ...params.args?.where,
           // allow overriding the deleted field in where
-          [config.field]: params.args?.where?.[config.field] || config.createValue(false),
+          ...(params.args?.where?.[config.field]
+            ? {
+                [config.field]: params.args?.where?.[config.field],
+              }
+            : config.createUpdates(false)),
         },
       },
     },
@@ -255,8 +263,11 @@ export const createFindFirstParams: CreateParams = (config, params) => {
         where: {
           ...params.args?.where,
           // allow overriding the deleted field in where
-          [config.field]:
-            params.args?.where?.[config.field] || config.createValue(false),
+          ...(params.args?.where?.[config.field]
+            ? {
+                [config.field]: params.args?.where?.[config.field],
+              }
+            : config.createUpdates(false)),
         },
       },
     },
@@ -273,8 +284,11 @@ export const createFindFirstOrThrowParams: CreateParams = (config, params) => {
         where: {
           ...params.args?.where,
           // allow overriding the deleted field in where
-          [config.field]:
-            params.args?.where?.[config.field] || config.createValue(false),
+          ...(params.args?.where?.[config.field]
+            ? {
+                [config.field]: params.args?.where?.[config.field],
+              }
+            : config.createUpdates(false)),
         },
       },
     },
@@ -291,8 +305,11 @@ export const createFindManyParams: CreateParams = (config, params) => {
         where: {
           ...params.args?.where,
           // allow overriding the deleted field in where
-          [config.field]:
-            params.args?.where?.[config.field] || config.createValue(false),
+          ...(params.args?.where?.[config.field]
+            ? {
+                [config.field]: params.args?.where?.[config.field],
+              }
+            : config.createUpdates(false)),
         },
       },
     },
@@ -310,8 +327,11 @@ export const createGroupByParams: CreateParams = (config, params) => {
         where: {
           ...params.args?.where,
           // allow overriding the deleted field in where
-          [config.field]:
-            params.args?.where?.[config.field] || config.createValue(false),
+          ...(params.args?.where?.[config.field]
+            ? {
+                [config.field]: params.args?.where?.[config.field],
+              }
+            : config.createUpdates(false)),
         },
       },
     },
@@ -330,7 +350,11 @@ export const createCountParams: CreateParams = (config, params) => {
         where: {
           ...where,
           // allow overriding the deleted field in where
-          [config.field]: where[config.field] || config.createValue(false),
+          ...(where[config.field]
+            ? {
+                [config.field]: where[config.field],
+              }
+            : config.createUpdates(false)),
         },
       },
     },
@@ -349,7 +373,11 @@ export const createAggregateParams: CreateParams = (config, params) => {
         where: {
           ...where,
           // allow overriding the deleted field in where
-          [config.field]: where[config.field] || config.createValue(false),
+          ...(where[config.field]
+            ? {
+                [config.field]: where[config.field],
+              }
+            : config.createUpdates(false)),
         },
       },
     },
@@ -365,10 +393,7 @@ export const createWhereParams: CreateParams = (config, params) => {
       params: {
         ...params,
         args: {
-          OR: [
-            { [config.field]: { not: config.createValue(false) } },
-            params.args,
-          ],
+          OR: [{ NOT: config.createUpdates(false) }, params.args],
         },
       },
     };
@@ -379,7 +404,11 @@ export const createWhereParams: CreateParams = (config, params) => {
       ...params,
       args: {
         ...params.args,
-        [config.field]: params.args[config.field] || config.createValue(false),
+        ...(params.args[config.field]
+          ? {
+              [config.field]: params.args[config.field],
+            }
+          : config.createUpdates(false)),
       },
     },
   };
@@ -407,8 +436,11 @@ export const createIncludeParams: CreateParams = (config, params) => {
         where: {
           ...params.args?.where,
           // allow overriding the deleted field in where
-          [config.field]:
-            params.args?.where?.[config.field] || config.createValue(false),
+          ...(params.args?.where?.[config.field]
+            ? {
+                [config.field]: params.args?.where?.[config.field],
+              }
+            : config.createUpdates(false)),
         },
       },
     },
@@ -441,8 +473,11 @@ export const createSelectParams: CreateParams = (config, params) => {
         where: {
           ...params.args?.where,
           // allow overriding the deleted field in where
-          [config.field]:
-            params.args?.where?.[config.field] || config.createValue(false),
+          ...(params.args?.where?.[config.field]
+            ? {
+                [config.field]: params.args?.where?.[config.field],
+              }
+            : config.createUpdates(false)),
         },
       },
     },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,13 +1,15 @@
 import { Prisma } from "@prisma/client";
 
-export type ModelConfig = {
-  field: string;
-  createValue: (deleted: boolean) => any;
+export type ModelConfig<FIELD extends string = string> = {
+  field: FIELD;
+  createUpdates: (
+    deleted: boolean
+  ) => ({ [key: string]: any } & { [key in FIELD]: any }) | Record<FIELD, null>;
   allowToOneUpdates?: boolean;
   allowCompoundUniqueIndexWhere?: boolean;
 };
 
-export type Config = {
-  models: Partial<Record<Prisma.ModelName, ModelConfig | boolean>>;
-  defaultConfig?: ModelConfig;
+export type Config<FIELD extends string = string> = {
+  models: Partial<Record<Prisma.ModelName, ModelConfig<FIELD> | boolean>>;
+  defaultConfig?: ModelConfig<FIELD>;
 };

--- a/test/e2e/deletedAt.test.ts
+++ b/test/e2e/deletedAt.test.ts
@@ -12,18 +12,16 @@ describe("deletedAt", () => {
   beforeAll(async () => {
     testClient = new PrismaClient();
     testClient = testClient.$extends(
-      createSoftDeleteExtension(
-        {
-          models: {
-            User: {
-              field: "deletedAt",
-              createValue: (deleted) => {
-                return deleted ? new Date() : null;
-              },
+      createSoftDeleteExtension({
+        models: {
+          User: {
+            field: "deletedAt",
+            createUpdates: (deleted) => {
+              return deleted ? { deletedAt: new Date() } : { deletedAt: null };
             },
           },
         },
-      )
+      })
     );
 
     profile = await client.profile.create({

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -52,7 +52,9 @@ describe("config", () => {
         },
         defaultConfig: {
           field: "deletedAt",
-          createValue: () => deletedAt,
+          createUpdates: (deleted) => {
+            return { deletedAt };
+          },
         },
       })
     );
@@ -99,7 +101,9 @@ describe("config", () => {
         },
         // @ts-expect-error - we are testing the error case
         defaultConfig: {
-          createValue: () => new Date(),
+          createUpdates: (deleted) => {
+            return { deletedAt: new Date() };
+          },
         },
       });
     }).toThrowError(
@@ -131,7 +135,9 @@ describe("config", () => {
         models: {
           Post: {
             field: "deletedAt",
-            createValue: () => deletedAt,
+            createUpdates: (deleted) => {
+              return { deletedAt };
+            },
           },
           Comment: true,
         },
@@ -176,14 +182,15 @@ describe("config", () => {
           Post: true,
           Comment: {
             field: "deleted",
-            createValue: Boolean,
+            createUpdates: (deleted) => {
+              return { deleted };
+            },
           },
         },
         defaultConfig: {
           field: "deletedAt",
-          createValue: (deleted) => {
-            if (deleted) return deletedAt;
-            return null;
+          createUpdates: (deleted) => {
+            return deleted ? { deletedAt } : { deletedAt: null };
           },
         },
       })

--- a/test/unit/findUnique.test.ts
+++ b/test/unit/findUnique.test.ts
@@ -109,7 +109,9 @@ describe("findUnique", () => {
         models: {
           User: {
             field: "deleted",
-            createValue: Boolean,
+            createUpdates: (deleted) => {
+              return { deleted };
+            },
             allowCompoundUniqueIndexWhere: true,
           },
         },
@@ -149,7 +151,9 @@ describe("findUnique", () => {
     await extendedClient.user.findUnique(undefined);
 
     // params have not been modified
-    expect(extendedClient.user.findUnique.query).toHaveBeenCalledWith(undefined);
+    expect(extendedClient.user.findUnique.query).toHaveBeenCalledWith(
+      undefined
+    );
     expect(client.user.findFirst).not.toHaveBeenCalled();
   });
 
@@ -169,7 +173,9 @@ describe("findUnique", () => {
     // expect empty where not to modify params
     // @ts-expect-error testing if user passes where without unique field
     await extendedClient.user.findUnique({ where: {} });
-    expect(extendedClient.user.findUnique.query).toHaveBeenCalledWith({ where: {} });
+    expect(extendedClient.user.findUnique.query).toHaveBeenCalledWith({
+      where: {},
+    });
     client.user.findUnique.mockClear();
 
     // expect where with undefined id field not to modify params

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -68,7 +68,9 @@ describe("update", () => {
         models: { User: true },
         defaultConfig: {
           field: "deleted",
-          createValue: Boolean,
+          createUpdates: (deleted) => {
+            return { deleted };
+          },
           allowToOneUpdates: true,
         },
       })

--- a/test/unit/updateMany.test.ts
+++ b/test/unit/updateMany.test.ts
@@ -48,7 +48,9 @@ describe("updateMany", () => {
     await extendedClient.user.updateMany(undefined);
 
     // params have not been modified
-    expect(extendedClient.user.updateMany.query).toHaveBeenCalledWith(undefined);
+    expect(extendedClient.user.updateMany.query).toHaveBeenCalledWith(
+      undefined
+    );
   });
 
   it("excludes deleted records from root updateMany action", async () => {
@@ -175,9 +177,8 @@ describe("updateMany", () => {
         models: {
           User: {
             field: "deletedAt",
-            createValue: (deleted) => {
-              if (deleted) return new Date();
-              return null;
+            createUpdates: (deleted) => {
+              return deleted ? { deletedAt: new Date() } : { deletedAt: null };
             },
           },
         },

--- a/test/unit/where.test.ts
+++ b/test/unit/where.test.ts
@@ -149,7 +149,7 @@ describe("where", () => {
             deleted: false,
           },
           every: {
-            OR: [{ deleted: { not: false } }, { content: expect.any(String) }],
+            OR: [{ NOT: { deleted: false } }, { content: expect.any(String) }],
           },
           none: {
             content: expect.any(String),


### PR DESCRIPTION
In Rally, we have 2 columns to identify deleted: DeletedAt and IsNotDeleted. On soft delete, we need to update deletedAt = Date and isNotDeleted = null. To achieve this replaced `createValue` function with `createUpdates` (in `src/lib/types.ts`) which can return a dict of updates on deletes. Other diff is downstream affect of this change. 