### PR TITLE
Add multiple deletion fields

### DIFF
--- a/src/lib/createSoftDeleteExtension.ts
+++ b/src/lib/createSoftDeleteExtension.ts
@@ -34,13 +34,13 @@ type ConfigBound<F> = F extends (x: ModelConfig, ...args: infer P) => infer R
 export function createSoftDeleteExtension({
   models,
   defaultConfig = {
-    field: "deleted",
+    fields: ["deleted"],
     createUpdates: (deleted: boolean) => ({ deleted }),
     allowToOneUpdates: false,
     allowCompoundUniqueIndexWhere: false,
   },
 }: Config) {
-  if (!defaultConfig.field) {
+  if (!defaultConfig.fields || defaultConfig.fields.length === 0) {
     throw new Error(
       "prisma-extension-soft-delete: defaultConfig.field is required"
     );

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,15 +1,15 @@
 import { Prisma } from "@prisma/client";
 
-export type ModelConfig<FIELD extends string = string> = {
-  field: FIELD;
+export type ModelConfig = {
+  fields: string[];
   createUpdates: (
     deleted: boolean
-  ) => ({ [key: string]: any } & { [key in FIELD]: any }) | Record<FIELD, null>;
+  ) => Record<ModelConfig["fields"][number], any>;
   allowToOneUpdates?: boolean;
   allowCompoundUniqueIndexWhere?: boolean;
 };
 
-export type Config<FIELD extends string = string> = {
-  models: Partial<Record<Prisma.ModelName, ModelConfig<FIELD> | boolean>>;
-  defaultConfig?: ModelConfig<FIELD>;
+export type Config = {
+  models: Partial<Record<Prisma.ModelName, ModelConfig | boolean>>;
+  defaultConfig?: ModelConfig;
 };

--- a/src/lib/utils/hasAnyConfigField.ts
+++ b/src/lib/utils/hasAnyConfigField.ts
@@ -1,0 +1,17 @@
+import { ModelConfig } from "../types";
+
+export const hasAnyConfigField = (
+  obj: any,
+  configFields: string[]
+): boolean => {
+  // Account for where and select fields
+  return configFields.some((f) => obj?.[f] !== undefined || obj?.[f] === true);
+};
+
+export const hasAnyConfigFieldNonDeletedValue = (
+  obj: any,
+  config: ModelConfig
+): boolean => {
+  const nonDeletedFieldValue = config.createUpdates(false);
+  return config.fields.some((f) => nonDeletedFieldValue[f] === obj?.[f]);
+};

--- a/src/lib/utils/nestedReads.ts
+++ b/src/lib/utils/nestedReads.ts
@@ -4,14 +4,17 @@ export function addDeletedToSelect<T extends { args?: any }>(
   params: T,
   config: ModelConfig
 ): T {
-  if (params.args.select && !params.args.select[config.field]) {
+  if (params.args.select) {
     return {
       ...params,
       args: {
         ...params.args,
         select: {
           ...params.args.select,
-          [config.field]: true,
+          ...config.fields.reduce<{ [key: string]: boolean }>((acc, field) => {
+            acc[field] = true;
+            return acc;
+          }, {}),
         },
       },
     };
@@ -26,10 +29,14 @@ export function stripDeletedFieldFromResults(
 ) {
   if (Array.isArray(results)) {
     results?.forEach((item: any) => {
-      delete item[config.field];
+      config.fields.forEach((field) => {
+        delete item[field];
+      });
     });
   } else if (results) {
-    delete results[config.field];
+    config.fields.forEach((field) => {
+      delete results[field];
+    });
   }
 
   return results;

--- a/src/lib/utils/resultFiltering.ts
+++ b/src/lib/utils/resultFiltering.ts
@@ -1,4 +1,8 @@
 import { ModelConfig } from "../types";
+import {
+  hasAnyConfigField,
+  hasAnyConfigFieldNonDeletedValue,
+} from "./hasAnyConfigField";
 
 // Maybe this should return true for non-list relations only?
 export function shouldFilterDeletedFromReadResult(
@@ -7,19 +11,23 @@ export function shouldFilterDeletedFromReadResult(
 ): boolean {
   return (
     !params.args.where ||
-    typeof params.args.where[config.field] === "undefined" ||
-    !params.args.where[config.field]
+    !hasAnyConfigField(params.args.where, config.fields) ||
+    hasAnyConfigFieldNonDeletedValue(params.args.where, config)
   );
 }
 
 export function filterSoftDeletedResults(result: any, config: ModelConfig) {
   // filter out deleted records from array results
   if (result && Array.isArray(result)) {
-    return result.filter((item) => !item[config.field]);
+    return result.filter(
+      (item) =>
+        !hasAnyConfigField(item, config.fields) ||
+        hasAnyConfigFieldNonDeletedValue(item, config)
+    );
   }
 
   // if the result is deleted return null
-  if (result && result[config.field]) {
+  if (result && !hasAnyConfigFieldNonDeletedValue(result, config)) {
     return null;
   }
 

--- a/test/e2e/deletedAt.test.ts
+++ b/test/e2e/deletedAt.test.ts
@@ -15,7 +15,7 @@ describe("deletedAt", () => {
       createSoftDeleteExtension({
         models: {
           User: {
-            field: "deletedAt",
+            fields: ["deletedAt"],
             createUpdates: (deleted) => {
               return deleted ? { deletedAt: new Date() } : { deletedAt: null };
             },

--- a/test/unit/config.test.ts
+++ b/test/unit/config.test.ts
@@ -51,7 +51,7 @@ describe("config", () => {
           Comment: true,
         },
         defaultConfig: {
-          field: "deletedAt",
+          fields: ["deletedAt"],
           createUpdates: (deleted) => {
             return { deletedAt };
           },
@@ -119,7 +119,7 @@ describe("config", () => {
         },
         // @ts-expect-error - we are testing the error case
         defaultConfig: {
-          field: "deletedAt",
+          fields: ["deletedAt"],
         },
       });
     }).toThrowError(
@@ -134,7 +134,7 @@ describe("config", () => {
       createSoftDeleteExtension({
         models: {
           Post: {
-            field: "deletedAt",
+            fields: ["deletedAt"],
             createUpdates: (deleted) => {
               return { deletedAt };
             },
@@ -181,14 +181,14 @@ describe("config", () => {
         models: {
           Post: true,
           Comment: {
-            field: "deleted",
+            fields: ["deleted"],
             createUpdates: (deleted) => {
               return { deleted };
             },
           },
         },
         defaultConfig: {
-          field: "deletedAt",
+          fields: ["deletedAt"],
           createUpdates: (deleted) => {
             return deleted ? { deletedAt } : { deletedAt: null };
           },

--- a/test/unit/findUnique.test.ts
+++ b/test/unit/findUnique.test.ts
@@ -108,7 +108,7 @@ describe("findUnique", () => {
       createSoftDeleteExtension({
         models: {
           User: {
-            field: "deleted",
+            fields: ["deleted"],
             createUpdates: (deleted) => {
               return { deleted };
             },

--- a/test/unit/update.test.ts
+++ b/test/unit/update.test.ts
@@ -67,7 +67,7 @@ describe("update", () => {
       createSoftDeleteExtension({
         models: { User: true },
         defaultConfig: {
-          field: "deleted",
+          fields: ["deleted"],
           createUpdates: (deleted) => {
             return { deleted };
           },

--- a/test/unit/updateMany.test.ts
+++ b/test/unit/updateMany.test.ts
@@ -176,7 +176,7 @@ describe("updateMany", () => {
       createSoftDeleteExtension({
         models: {
           User: {
-            field: "deletedAt",
+            fields: ["deletedAt"],
             createUpdates: (deleted) => {
               return deleted ? { deletedAt: new Date() } : { deletedAt: null };
             },


### PR DESCRIPTION
This PR adds multiple fields for deletions. In Rally, this would be `deletedAt` and `isNotDeleted`. 

The new `fields` will look for either of the fields to confirm deletion.